### PR TITLE
Fix markup in spec

### DIFF
--- a/spec/markaby_to_erb_spec.rb
+++ b/spec/markaby_to_erb_spec.rb
@@ -522,7 +522,7 @@ RSpec.describe MarkabyToErb::Converter do
     MARKABY
     expected_erb = <<~ERB.strip
       <div>
-        <\%= @some_var %>
+        <%= @some_var %>
       </div>
     ERB
     expect_conversion(markaby_code, expected_erb)


### PR DESCRIPTION
## Summary
- correct spec markup for some_var rendering

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 Forbidden)*
- `bundle exec rspec spec/markaby_to_erb_spec.rb` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_6851e92b00008324909fc296a8cc4d24