### PR TITLE
Add parser gem runtime dependency

### DIFF
--- a/markaby_to_erb.gemspec
+++ b/markaby_to_erb.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |spec|
 
   # Specify the required Ruby version
   spec.required_ruby_version = '>= 2.5.0'
+
+  spec.add_dependency 'parser', '~> 3.0'
 end


### PR DESCRIPTION
## Summary
- declare parser runtime dependency in gemspec

## Testing
- `bundle exec rspec` *(fails: bundler cannot access rubygems)*

------
https://chatgpt.com/codex/tasks/task_e_6851fead717c83249651c495d9e8be23